### PR TITLE
Fix for Ubuntu 16.04

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -48,7 +48,7 @@ class sentry::setup (
       ensure_packages([
         'build-essential',
         'libffi-dev',
-        'libjpeg62-turbo-dev',
+        'libjpeg-dev',
         'libxml2-dev',
         'libxslt1-dev',
         'libldap2-dev',


### PR DESCRIPTION
Depends on 
* libjpeg8-dev on Ubuntu 16.04
* libjpeg62-turbo-dev on Debian 8.x